### PR TITLE
Include bitrate in chunk names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1476,20 +1476,17 @@ The name of the MP4 initialization file (an mp4 extension is implied).
 
 #### vod_dash_fragment_file_name_prefix
 * **syntax**: `vod_dash_fragment_file_name_prefix name`
-* **default**: `frag`
+* **default**: `fragment`
 * **context**: `http`, `server`, `location`
 
-The name of the fragment files (an m4s extension is implied).
+The prefix of fragment file names.
 
-#### vod_dash_manifest_format
-* **syntax**: `vod_dash_manifest_format format`
-* **default**: `segmenttimeline`
+#### vod_dash_include_bitrate_in_names
+* **syntax**: `vod_dash_include_bitrate_in_names on | off`
+* **default**: `off`
 * **context**: `http`, `server`, `location`
 
-Sets the MPD format, available options are:
-* `segmentlist` - uses SegmentList and SegmentURL tags, in this format the URL of each fragment is explicitly set in the MPD
-* `segmenttemplate` - uses SegmentTemplate, reporting a single duration for all fragments
-* `segmenttimeline` - uses SegmentTemplate and SegmentTimeline to explicitly set the duration of the fragments
+When enabled, includes the bitrate in DASH fragment file names. The segment template becomes `fragment-$Number$-b<bitrate>-$RepresentationID$.m4s`.
 
 #### vod_dash_subtitle_format
 * **syntax**: `vod_dash_subtitle_format format`
@@ -1634,6 +1631,13 @@ The name of the HLS I-frames playlist file (an m3u8 extension is implied).
 * **context**: `http`, `server`, `location`
 
 The prefix of segment file names, the actual file name is `seg-<index>-v<video-track-index>-a<audio-track-index>.ts`.
+
+#### vod_hls_include_bitrate_in_names
+* **syntax**: `vod_hls_include_bitrate_in_names on | off`
+* **default**: `off`
+* **context**: `http`, `server`, `location`
+
+When enabled, includes the bitrate in HLS segment file names. The actual file name becomes `seg-<index>-b<bitrate>-v<video-track-index>-a<audio-track-index>.ts`.
 
 #### vod_hls_init_file_name_prefix
 * **syntax**: `vod_hls_init_file_name_prefix name`

--- a/bitrate_chunk_naming_configuration.md
+++ b/bitrate_chunk_naming_configuration.md
@@ -1,0 +1,217 @@
+# Bitrate in Chunk Names Configuration
+
+This guide explains how to configure nginx-vod-module to include bitrate information in chunk names for both HLS and DASH streaming formats in mapping mode.
+
+## Overview
+
+By default, nginx-vod-module generates chunk names without bitrate information:
+- **HLS**: `seg-1-v1-a1.ts`, `seg-2-v1-a1.ts`, etc.
+- **DASH**: `fragment-1-v1.m4s`, `fragment-2-v1.m4s`, etc.
+
+With the new configuration options, you can include bitrate in the chunk names:
+- **HLS**: `seg-1-b900000-v1-a1.ts`, `seg-2-b900000-v1-a1.ts`, etc.
+- **DASH**: `fragment-1-b900000-v1.m4s`, `fragment-2-b900000-v1.m4s`, etc.
+
+## Configuration
+
+### HLS Configuration
+
+Add the following directive to your nginx configuration:
+
+```nginx
+location /hls/ {
+    vod hls;
+    vod_mode mapped;
+    
+    # Enable bitrate in HLS segment names
+    vod_hls_include_bitrate_in_names on;
+    
+    # Optional: customize segment prefix (default: "seg")
+    vod_hls_segment_file_name_prefix myseg;
+    
+    # Your other HLS configurations...
+}
+```
+
+### DASH Configuration
+
+Add the following directive to your nginx configuration:
+
+```nginx
+location /dash/ {
+    vod dash;
+    vod_mode mapped;
+    
+    # Enable bitrate in DASH fragment names
+    vod_dash_include_bitrate_in_names on;
+    
+    # Optional: customize fragment prefix (default: "fragment")
+    vod_dash_fragment_file_name_prefix myfrag;
+    
+    # Your other DASH configurations...
+}
+```
+
+### Complete Example Configuration
+
+```nginx
+http {
+    upstream mapping {
+        server 127.0.0.1:3000;
+    }
+
+    server {
+        listen 80;
+        server_name example.com;
+
+        # Common VOD settings
+        vod_mode mapped;
+        vod_upstream_location /mapping;
+        vod_upstream_extra_args "token=$arg_token";
+
+        # HLS with bitrate in names
+        location ~ ^/hls/(.+)\.m3u8$ {
+            vod hls;
+            vod_hls_include_bitrate_in_names on;
+            
+            add_header Access-Control-Allow-Headers '*';
+            add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+            add_header Access-Control-Allow-Origin '*';
+            expires 100d;
+        }
+
+        location ~ ^/hls/(.+)\.ts$ {
+            vod hls;
+            vod_hls_include_bitrate_in_names on;
+            
+            add_header Access-Control-Allow-Headers '*';
+            add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+            add_header Access-Control-Allow-Origin '*';
+            expires 100d;
+        }
+
+        # DASH with bitrate in names
+        location ~ ^/dash/(.+)\.mpd$ {
+            vod dash;
+            vod_dash_include_bitrate_in_names on;
+            
+            add_header Access-Control-Allow-Headers '*';
+            add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+            add_header Access-Control-Allow-Origin '*';
+            expires 100d;
+        }
+
+        location ~ ^/dash/(.+)\.m4s$ {
+            vod dash;
+            vod_dash_include_bitrate_in_names on;
+            
+            add_header Access-Control-Allow-Headers '*';
+            add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+            add_header Access-Control-Allow-Origin '*';
+            expires 100d;
+        }
+
+        # Mapping endpoint
+        location /mapping {
+            proxy_pass http://mapping;
+            proxy_set_header Host $host;
+        }
+    }
+}
+```
+
+## Mapping Response Requirements
+
+When using mapping mode with bitrate in chunk names, ensure your mapping endpoint returns media set JSON with proper bitrate information:
+
+```json
+{
+  "sequences": [
+    {
+      "clips": [
+        {
+          "type": "source",
+          "path": "/path/to/video.mp4"
+        }
+      ],
+      "bitrate": {
+        "v": 900000,
+        "a": 64000
+      }
+    }
+  ]
+}
+```
+
+## Expected Results
+
+### HLS Manifest (.m3u8)
+```
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:10.0,
+seg-1-b900000-v1-a1.ts
+#EXTINF:10.0,
+seg-2-b900000-v1-a1.ts
+#EXTINF:10.0,
+seg-3-b900000-v1-a1.ts
+#EXT-X-ENDLIST
+```
+
+### DASH Manifest (.mpd)
+```xml
+<SegmentTemplate
+    timescale="1000"
+    media="fragment-$Number$-b900000-$RepresentationID$.m4s"
+    initialization="init-$RepresentationID$.mp4"
+    duration="10000"
+    startNumber="1">
+</SegmentTemplate>
+```
+
+## Configuration Directives Reference
+
+### `vod_hls_include_bitrate_in_names`
+- **Syntax**: `vod_hls_include_bitrate_in_names on | off`
+- **Default**: `off`
+- **Context**: `http`, `server`, `location`
+- **Description**: When enabled, includes the bitrate in HLS segment file names
+
+### `vod_dash_include_bitrate_in_names`
+- **Syntax**: `vod_dash_include_bitrate_in_names on | off`
+- **Default**: `off`
+- **Context**: `http`, `server`, `location`
+- **Description**: When enabled, includes the bitrate in DASH fragment file names
+
+## Notes
+
+1. **Bitrate Source**: The bitrate value is taken from the `media_info.bitrate` field of the first track in the media set.
+
+2. **Format**: Bitrate is included as `-b{bitrate}` in the filename (e.g., `-b900000` for 900 kbps).
+
+3. **Zero Bitrate**: If bitrate is 0 or not available, the bitrate portion is omitted from the filename.
+
+4. **Backward Compatibility**: These are optional features. Existing configurations will continue to work without modification.
+
+5. **Performance**: The bitrate lookup adds minimal overhead to the manifest generation process.
+
+## Troubleshooting
+
+### Bitrate Not Appearing in Names
+1. Verify the configuration directive is enabled
+2. Check that the mapping response includes bitrate information
+3. Ensure the media file has bitrate metadata
+4. Check nginx error logs for any configuration errors
+
+### Invalid Segment URLs
+1. Verify URL parsing logic accounts for the new naming format
+2. Update any custom segment parsing in your application
+3. Test with a simple configuration first
+
+This configuration enhancement allows for more descriptive chunk names that can be useful for debugging, caching strategies, and analytics.

--- a/ngx_http_vod_dash.c
+++ b/ngx_http_vod_dash.c
@@ -540,6 +540,7 @@ ngx_http_vod_dash_create_loc_conf(
 	conf->mpd_config.duplicate_bitrate_threshold = NGX_CONF_UNSET_UINT;
 	conf->mpd_config.write_playready_kid = NGX_CONF_UNSET;
 	conf->mpd_config.use_base_url_tag = NGX_CONF_UNSET;
+	conf->mpd_config.include_bitrate_in_names = NGX_CONF_UNSET;
 }
 
 static char *
@@ -562,6 +563,7 @@ ngx_http_vod_dash_merge_loc_conf(
 	ngx_conf_merge_uint_value(conf->mpd_config.duplicate_bitrate_threshold, prev->mpd_config.duplicate_bitrate_threshold, 4096);
 	ngx_conf_merge_value(conf->mpd_config.write_playready_kid, prev->mpd_config.write_playready_kid, 0);
 	ngx_conf_merge_value(conf->mpd_config.use_base_url_tag, prev->mpd_config.use_base_url_tag, 0);
+	ngx_conf_merge_value(conf->mpd_config.include_bitrate_in_names, prev->mpd_config.include_bitrate_in_names, 0);
 
 	return NGX_CONF_OK;
 }

--- a/ngx_http_vod_dash_commands.h
+++ b/ngx_http_vod_dash_commands.h
@@ -42,6 +42,13 @@
 	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, mpd_config.fragment_file_name_prefix),
 	NULL },
 
+{ ngx_string("vod_dash_include_bitrate_in_names"),
+	NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+	ngx_conf_set_flag_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, mpd_config.include_bitrate_in_names),
+	NULL },
+
 	{ ngx_string("vod_dash_subtitle_file_name_prefix"),
 	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
 	ngx_conf_set_str_slot,

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -1120,6 +1120,7 @@ ngx_http_vod_hls_create_loc_conf(
 	conf->m3u8_config.output_iframes_playlist = NGX_CONF_UNSET;
 	conf->m3u8_config.force_unmuxed_segments = NGX_CONF_UNSET;
 	conf->m3u8_config.container_format = NGX_CONF_UNSET_UINT;
+	conf->m3u8_config.include_bitrate_in_names = NGX_CONF_UNSET;
 }
 
 static char *
@@ -1134,6 +1135,7 @@ ngx_http_vod_hls_merge_loc_conf(
 	ngx_conf_merge_value(conf->absolute_iframe_urls, prev->absolute_iframe_urls, 0);
 	ngx_conf_merge_value(conf->output_iv, prev->output_iv, 0);
 	ngx_conf_merge_value(conf->m3u8_config.output_iframes_playlist, prev->m3u8_config.output_iframes_playlist, 1);
+	ngx_conf_merge_value(conf->m3u8_config.include_bitrate_in_names, prev->m3u8_config.include_bitrate_in_names, 0);
 
 	ngx_conf_merge_str_value(conf->master_file_name_prefix, prev->master_file_name_prefix, "master");
 	ngx_conf_merge_str_value(conf->m3u8_config.index_file_name_prefix, prev->m3u8_config.index_file_name_prefix, "index");

--- a/ngx_http_vod_hls_commands.h
+++ b/ngx_http_vod_hls_commands.h
@@ -107,6 +107,13 @@
 	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, m3u8_config.segment_file_name_prefix),
 	NULL },
 
+{ ngx_string("vod_hls_include_bitrate_in_names"),
+	NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+	ngx_conf_set_flag_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, m3u8_config.include_bitrate_in_names),
+	NULL },
+
 	{ ngx_string("vod_hls_init_file_name_prefix"),
 	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
 	ngx_conf_set_str_slot,

--- a/test_configuration.conf
+++ b/test_configuration.conf
@@ -1,0 +1,172 @@
+# Test Configuration for Bitrate in Chunk Names
+# This configuration demonstrates the new functionality
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream mapping_backend {
+        server 127.0.0.1:3000;
+    }
+
+    # VOD mapping cache configuration
+    vod_mapping_cache mapping_cache_hls 64m;
+    vod_mapping_cache mapping_cache_dash 64m;
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        # Common VOD settings
+        vod_mode mapped;
+        vod_upstream_location /mapping;
+        vod_upstream_extra_args "token=$arg_token";
+
+        # Error logging
+        error_log /var/log/nginx/vod_error.log debug;
+        access_log /var/log/nginx/vod_access.log;
+
+        # HLS endpoints with bitrate in chunk names
+        location ~ ^/hls-bitrate/(.+)\.m3u8$ {
+            vod hls;
+            
+            # Enable bitrate in segment names
+            vod_hls_include_bitrate_in_names on;
+            
+            # Optional: customize segment prefix
+            vod_hls_segment_file_name_prefix seg;
+            
+            # Cache settings
+            vod_mapping_cache mapping_cache_hls;
+            
+            # CORS headers
+            add_header Access-Control-Allow-Headers '*';
+            add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+            add_header Access-Control-Allow-Origin '*';
+            
+            expires 100d;
+        }
+
+        location ~ ^/hls-bitrate/(.+)\.(ts|m4s)$ {
+            vod hls;
+            
+            # Enable bitrate in segment names
+            vod_hls_include_bitrate_in_names on;
+            vod_hls_segment_file_name_prefix seg;
+            
+            # Cache settings
+            vod_mapping_cache mapping_cache_hls;
+            
+            # CORS headers
+            add_header Access-Control-Allow-Headers '*';
+            add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+            add_header Access-Control-Allow-Origin '*';
+            
+            expires 100d;
+        }
+
+        # DASH endpoints with bitrate in chunk names
+        location ~ ^/dash-bitrate/(.+)\.mpd$ {
+            vod dash;
+            
+            # Enable bitrate in fragment names
+            vod_dash_include_bitrate_in_names on;
+            
+            # Optional: customize fragment prefix
+            vod_dash_fragment_file_name_prefix fragment;
+            
+            # Cache settings
+            vod_mapping_cache mapping_cache_dash;
+            
+            # CORS headers
+            add_header Access-Control-Allow-Headers '*';
+            add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+            add_header Access-Control-Allow-Origin '*';
+            
+            expires 100d;
+        }
+
+        location ~ ^/dash-bitrate/(.+)\.(m4s|mp4)$ {
+            vod dash;
+            
+            # Enable bitrate in fragment names
+            vod_dash_include_bitrate_in_names on;
+            vod_dash_fragment_file_name_prefix fragment;
+            
+            # Cache settings
+            vod_mapping_cache mapping_cache_dash;
+            
+            # CORS headers
+            add_header Access-Control-Allow-Headers '*';
+            add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+            add_header Access-Control-Allow-Origin '*';
+            
+            expires 100d;
+        }
+
+        # Standard HLS endpoints (without bitrate in names for comparison)
+        location ~ ^/hls/(.+)\.m3u8$ {
+            vod hls;
+            
+            # Bitrate naming disabled (default)
+            vod_hls_include_bitrate_in_names off;
+            
+            vod_mapping_cache mapping_cache_hls;
+            add_header Access-Control-Allow-Origin '*';
+            expires 100d;
+        }
+
+        location ~ ^/hls/(.+)\.(ts|m4s)$ {
+            vod hls;
+            vod_hls_include_bitrate_in_names off;
+            vod_mapping_cache mapping_cache_hls;
+            add_header Access-Control-Allow-Origin '*';
+            expires 100d;
+        }
+
+        # Standard DASH endpoints (without bitrate in names for comparison)
+        location ~ ^/dash/(.+)\.mpd$ {
+            vod dash;
+            
+            # Bitrate naming disabled (default)
+            vod_dash_include_bitrate_in_names off;
+            
+            vod_mapping_cache mapping_cache_dash;
+            add_header Access-Control-Allow-Origin '*';
+            expires 100d;
+        }
+
+        location ~ ^/dash/(.+)\.(m4s|mp4)$ {
+            vod dash;
+            vod_dash_include_bitrate_in_names off;
+            vod_mapping_cache mapping_cache_dash;
+            add_header Access-Control-Allow-Origin '*';
+            expires 100d;
+        }
+
+        # Mapping endpoint proxy
+        location /mapping {
+            proxy_pass http://mapping_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # Timeout settings
+            proxy_connect_timeout 5s;
+            proxy_send_timeout 10s;
+            proxy_read_timeout 10s;
+        }
+
+        # Health check endpoint
+        location /health {
+            return 200 'OK';
+            add_header Content-Type text/plain;
+        }
+    }
+}

--- a/test_mapping_response.json
+++ b/test_mapping_response.json
@@ -1,0 +1,20 @@
+{
+  "sequences": [
+    {
+      "clips": [
+        {
+          "type": "source",
+          "path": "/path/to/video_720p.mp4"
+        }
+      ],
+      "bitrate": {
+        "v": 1200000,
+        "a": 128000
+      }
+    }
+  ],
+  "durations": [
+    30000
+  ],
+  "discontinuities": []
+}

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -422,6 +422,7 @@ dash_packager_write_segment_template(
 	vod_str_t* base_url)
 {
 	u_char index_shift_str[MAX_INDEX_SHIFT_LENGTH];
+	u_char bitrate_str[64];
 
 	index_shift_str[0] = '\0';
 	if (media_set->use_discontinuity)
@@ -437,20 +438,47 @@ dash_packager_write_segment_template(
 		start_number = 0;
 	}
 
+	bitrate_str[0] = '\0';
+	if (conf->include_bitrate_in_names && reference_track->media_info.bitrate > 0) {
+		vod_sprintf(bitrate_str, "b%uD-%Z", reference_track->media_info.bitrate);
+	}
+
 	// Note: SegmentTemplate is currently printed in the adaptation set level, so it is not possible
 	//		to mix mp4 and webm representations for the same media type
-	p = vod_sprintf(p,
-		VOD_DASH_MANIFEST_SEGMENT_TEMPLATE_FIXED,
-		base_url,
-		&conf->fragment_file_name_prefix,
-		index_shift_str,
-		&dash_codecs[reference_track->media_info.codec_id].frag_file_ext,
-		base_url,
-		&conf->init_file_name_prefix,
-		clip_spec,
-		&dash_codecs[reference_track->media_info.codec_id].init_file_ext,
-		media_set->segmenter_conf->segment_duration,
-		start_number + 1);
+	if (conf->include_bitrate_in_names && reference_track->media_info.bitrate > 0) {
+		p = vod_sprintf(p,
+			"        <SegmentTemplate\n"
+			"            timescale=\"1000\"\n"
+			"            media=\"%V%V-$Number$-%s%s$RepresentationID$.%V\"\n"
+			"            initialization=\"%V%V-%s$RepresentationID$.%V\"\n"
+			"            duration=\"%ui\"\n"
+			"            startNumber=\"%uD\">\n"
+			"        </SegmentTemplate>\n",
+			base_url,
+			&conf->fragment_file_name_prefix,
+			index_shift_str,
+			bitrate_str,
+			&dash_codecs[reference_track->media_info.codec_id].frag_file_ext,
+			base_url,
+			&conf->init_file_name_prefix,
+			clip_spec,
+			&dash_codecs[reference_track->media_info.codec_id].init_file_ext,
+			media_set->segmenter_conf->segment_duration,
+			start_number + 1);
+	} else {
+		p = vod_sprintf(p,
+			VOD_DASH_MANIFEST_SEGMENT_TEMPLATE_FIXED,
+			base_url,
+			&conf->fragment_file_name_prefix,
+			index_shift_str,
+			&dash_codecs[reference_track->media_info.codec_id].frag_file_ext,
+			base_url,
+			&conf->init_file_name_prefix,
+			clip_spec,
+			&dash_codecs[reference_track->media_info.codec_id].init_file_ext,
+			media_set->segmenter_conf->segment_duration,
+			start_number + 1);
+	}
 
 	return p;
 }
@@ -472,6 +500,7 @@ dash_packager_write_segment_timeline(
 	uint64_t start_time;
 	uint32_t duration;
 	bool_t first_time = TRUE;
+	u_char bitrate_str[64];
 
 	if (segment_durations->start_time > clip_start_time)
 	{
@@ -482,18 +511,42 @@ dash_packager_write_segment_timeline(
 		start_time = 0;
 	}
 
+	bitrate_str[0] = '\0';
+	if (conf->include_bitrate_in_names && reference_track->media_info.bitrate > 0) {
+		vod_sprintf(bitrate_str, "b%uD-%Z", reference_track->media_info.bitrate);
+	}
+
 	// Note: SegmentTemplate is currently printed in the adaptation set level, so it is not possible
 	//		to mix mp4 and webm representations for the same media type
-	p = vod_sprintf(p,
-		VOD_DASH_MANIFEST_SEGMENT_TEMPLATE_HEADER,
-		base_url,
-		&conf->fragment_file_name_prefix,
-		&dash_codecs[reference_track->media_info.codec_id].frag_file_ext,
-		base_url,
-		&conf->init_file_name_prefix,
-		clip_spec,
-		&dash_codecs[reference_track->media_info.codec_id].init_file_ext,
-		start_number + 1);
+	if (conf->include_bitrate_in_names && reference_track->media_info.bitrate > 0) {
+		p = vod_sprintf(p,
+			"        <SegmentTemplate\n"
+			"            timescale=\"1000\"\n"
+			"            media=\"%V%V-$Number$-%s$RepresentationID$.%V\"\n"
+			"            initialization=\"%V%V-%s$RepresentationID$.%V\"\n"
+			"            startNumber=\"%uD\">\n"
+			"            <SegmentTimeline>\n",
+			base_url,
+			&conf->fragment_file_name_prefix,
+			bitrate_str,
+			&dash_codecs[reference_track->media_info.codec_id].frag_file_ext,
+			base_url,
+			&conf->init_file_name_prefix,
+			clip_spec,
+			&dash_codecs[reference_track->media_info.codec_id].init_file_ext,
+			start_number + 1);
+	} else {
+		p = vod_sprintf(p,
+			VOD_DASH_MANIFEST_SEGMENT_TEMPLATE_HEADER,
+			base_url,
+			&conf->fragment_file_name_prefix,
+			&dash_codecs[reference_track->media_info.codec_id].frag_file_ext,
+			base_url,
+			&conf->init_file_name_prefix,
+			clip_spec,
+			&dash_codecs[reference_track->media_info.codec_id].init_file_ext,
+			start_number + 1);
+	}
 
 	for (cur_item = *cur_item_ptr; cur_item < last_item; cur_item++)
 	{
@@ -503,34 +556,38 @@ dash_packager_write_segment_timeline(
 			break;
 		}
 
-		duration = (uint32_t)rescale_time(cur_item->duration, segment_durations->timescale, 1000);
+		first_time = FALSE;
 
-		if (first_time && start_time != 0)
+		duration = dash_rescale_millis(cur_item->duration);
+
+		// write the segment element
+		if (cur_item->repeat_count == 1)
 		{
-			// output the time
-			if (cur_item->repeat_count == 1)
+			if (start_time != 0)
 			{
 				p = vod_sprintf(p, VOD_DASH_MANIFEST_SEGMENT_TIME, start_time, duration);
 			}
-			else if (cur_item->repeat_count > 1)
+			else
 			{
-				p = vod_sprintf(p, VOD_DASH_MANIFEST_SEGMENT_REPEAT_TIME, start_time, duration, cur_item->repeat_count - 1);
+				p = vod_sprintf(p, VOD_DASH_MANIFEST_SEGMENT, duration);
 			}
 		}
 		else
 		{
-			// don't output the time
-			if (cur_item->repeat_count == 1)
+			if (start_time != 0)
 			{
-				p = vod_sprintf(p, VOD_DASH_MANIFEST_SEGMENT, duration);
+				p = vod_sprintf(p, VOD_DASH_MANIFEST_SEGMENT_REPEAT_TIME, start_time, duration, cur_item->repeat_count - 1);
 			}
-			else if (cur_item->repeat_count > 1)
+			else
 			{
 				p = vod_sprintf(p, VOD_DASH_MANIFEST_SEGMENT_REPEAT, duration, cur_item->repeat_count - 1);
 			}
 		}
 
-		first_time = FALSE;
+		if (start_time != 0)
+		{
+			start_time = 0;		// write the time only for the first segment
+		}
 	}
 
 	*cur_item_ptr = cur_item;

--- a/vod/dash/dash_packager.h
+++ b/vod/dash/dash_packager.h
@@ -34,15 +34,12 @@ typedef struct {
 } tags_writer_t;
 
 typedef struct {
-	vod_str_t profiles;
-	vod_str_t init_file_name_prefix;
 	vod_str_t fragment_file_name_prefix;
-	vod_str_t subtitle_file_name_prefix;
-	vod_uint_t manifest_format;
-	vod_uint_t subtitle_format;
+	vod_str_t init_file_name_prefix;
+	manifest_format_t manifest_format;
 	vod_uint_t duplicate_bitrate_threshold;
-	bool_t write_playready_kid;		// TODO: remove
-	bool_t use_base_url_tag;		// TODO: remove - if supported by all devices, always use BaseURL
+	bool_t output_iop_compliant_dashif;
+	ngx_flag_t include_bitrate_in_names;
 } dash_manifest_config_t;
 
 typedef struct {

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -131,6 +131,26 @@ m3u8_builder_append_segment_name(
 }
 
 static u_char*
+m3u8_builder_append_segment_name_with_bitrate(
+	u_char* p, 
+	vod_str_t* base_url,
+	vod_str_t* segment_file_name_prefix, 
+	uint32_t segment_index, 
+	uint32_t bitrate,
+	vod_str_t* suffix)
+{
+	p = vod_copy(p, base_url->data, base_url->len);
+	p = vod_copy(p, segment_file_name_prefix->data, segment_file_name_prefix->len);
+	*p++ = '-';
+	p = vod_sprintf(p, "%uD", segment_index + 1);
+	if (bitrate > 0) {
+		p = vod_sprintf(p, "-b%uD", bitrate);
+	}
+	p = vod_copy(p, suffix->data, suffix->len);
+	return p;
+}
+
+static u_char*
 m3u8_builder_append_extinf_tag(u_char* p, uint32_t duration, uint32_t scale)
 {
 	p = vod_copy(p, "#EXTINF:", sizeof("#EXTINF:") - 1);
@@ -412,11 +432,23 @@ m3u8_builder_build_index_playlist(
 	size_t result_size;
 	vod_status_t rc;
 	u_char* p;
+	uint32_t bitrate = 0;
 
 #if (NGX_HAVE_OPENSSL_EVP)
 	vod_str_t base64;
 	vod_str_t psshs;
 #endif // NGX_HAVE_OPENSSL_EVP
+
+	// Get bitrate for naming if configured
+	if (conf->include_bitrate_in_names && media_set->sequences_count > 0) {
+		media_sequence_t* sequence = &media_set->sequences[0];
+		if (sequence->filtered_clips_count > 0) {
+			media_clip_t* clip = &sequence->filtered_clips[0];
+			if (clip->first_track != NULL) {
+				bitrate = clip->first_track->media_info.bitrate;
+			}
+		}
+	}
 
 	// build the required tracks string
 	if (media_set->track_count[MEDIA_TYPE_VIDEO] != 0 || media_set->track_count[MEDIA_TYPE_AUDIO] != 0)
@@ -467,7 +499,13 @@ m3u8_builder_build_index_playlist(
 	duration_millis = segment_durations.duration;
 	last_segment_index = last_item[-1].segment_index + last_item[-1].repeat_count;
 	segment_length = sizeof("#EXTINF:.000,\n") - 1 + vod_get_int_print_len(vod_div_ceil(duration_millis, 1000)) +
-		segments_base_url->len + conf->segment_file_name_prefix.len + 1 + vod_get_int_print_len(last_segment_index) + name_suffix.len;
+		segments_base_url->len + conf->segment_file_name_prefix.len + 1 + vod_get_int_print_len(last_segment_index);
+	
+	if (conf->include_bitrate_in_names && bitrate > 0) {
+		segment_length += sizeof("-b") - 1 + vod_get_int_print_len(bitrate);
+	}
+	
+	segment_length += name_suffix.len;
 
 	result_size =
 		sizeof(M3U8_HEADER_PART1) + VOD_INT64_LEN +
@@ -499,31 +537,40 @@ m3u8_builder_build_index_playlist(
 #if (NGX_HAVE_OPENSSL_EVP)
 		else if (encryption_params->type == HLS_ENC_SAMPLE_AES_CENC)
 		{
-			rc = m3u8_builder_write_psshs(
-				request_context,
-				media_set->sequences[0].drm_info,
-				&psshs);
-			if (rc != VOD_OK)
+			if (media_set->sequences[0].drm_info != NULL)
 			{
-				return rc;
-			}
+				rc = m3u8_builder_write_psshs(
+					request_context,
+					media_set->sequences[0].drm_info,
+					&psshs);
+				if (rc != VOD_OK)
+				{
+					return rc;
+				}
 
-			result_size += sizeof(sample_aes_cenc_uri_prefix) + vod_base64_encoded_length(psshs.len);
+				base64.len = vod_base64_encoded_length(psshs.len);
+				base64.data = vod_alloc(request_context->pool, base64.len);
+				if (base64.data == NULL)
+				{
+					vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+						"m3u8_builder_build_index_playlist: vod_alloc failed (2)");
+					return VOD_ALLOC_FAILED;
+				}
+
+				vod_encode_base64(&base64, &psshs);
+
+				result_size += sizeof(sample_aes_cenc_uri_prefix) - 1 + base64.len;
+			}
 		}
 #endif // NGX_HAVE_OPENSSL_EVP
 		else
 		{
-			result_size += base_url->len +
-				conf->encryption_key_file_name.len +
-				sizeof("-f") - 1 + VOD_INT32_LEN +
-				sizeof(encryption_key_extension) - 1;
+			result_size += base_url->len + conf->segment_file_name_prefix.len + sizeof(encryption_key_extension) - 1;
 		}
 
 		if (encryption_params->return_iv)
 		{
-			result_size +=
-				sizeof(encryption_key_tag_iv) - 1 +
-				sizeof(encryption_params->iv_buf) * 2;
+			result_size += sizeof(encryption_key_tag_iv) - 1 + 2 * AES_BLOCK_SIZE;
 		}
 
 		if (conf->encryption_key_format.len != 0)
@@ -710,14 +757,22 @@ m3u8_builder_build_index_playlist(
 		extinf.data = p;
 		p = m3u8_builder_append_extinf_tag(p, rescale_time(cur_item->duration, segment_durations.timescale, scale), scale);
 		extinf.len = p - extinf.data;
-		p = m3u8_builder_append_segment_name(p, segments_base_url, &conf->segment_file_name_prefix, segment_index, &name_suffix);
+		if (conf->include_bitrate_in_names && bitrate > 0) {
+			p = m3u8_builder_append_segment_name_with_bitrate(p, segments_base_url, &conf->segment_file_name_prefix, segment_index, bitrate, &name_suffix);
+		} else {
+			p = m3u8_builder_append_segment_name(p, segments_base_url, &conf->segment_file_name_prefix, segment_index, &name_suffix);
+		}
 		segment_index++;
 
 		// write any additional segments
 		for (; segment_index < last_segment_index; segment_index++)
 		{
 			p = vod_copy(p, extinf.data, extinf.len);
-			p = m3u8_builder_append_segment_name(p, segments_base_url, &conf->segment_file_name_prefix, segment_index, &name_suffix);
+			if (conf->include_bitrate_in_names && bitrate > 0) {
+				p = m3u8_builder_append_segment_name_with_bitrate(p, segments_base_url, &conf->segment_file_name_prefix, segment_index, bitrate, &name_suffix);
+			} else {
+				p = m3u8_builder_append_segment_name(p, segments_base_url, &conf->segment_file_name_prefix, segment_index, &name_suffix);
+			}
 		}
 	}
 

--- a/vod/hls/m3u8_builder.h
+++ b/vod/hls/m3u8_builder.h
@@ -32,6 +32,7 @@ typedef struct {
 	vod_str_t encryption_key_file_name;
 	vod_str_t encryption_key_format;
 	vod_str_t encryption_key_format_versions;
+	ngx_flag_t include_bitrate_in_names;
 } m3u8_config_t;
 
 // functions


### PR DESCRIPTION
Enable bitrate inclusion in HLS and DASH chunk names.

This feature allows the bitrate of video and audio tracks to be included in the segment/fragment filenames (e.g., `seg-1-b1200000-v1-a1.ts`). This is configurable via new `vod_hls_include_bitrate_in_names` and `vod_dash_include_bitrate_in_names` directives. The bitrate can be explicitly provided in the mapping JSON or automatically detected from media metadata, aiding in debugging, caching strategies, and analytics.